### PR TITLE
Move API functions to lib/clientApi and clean up comments

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import Sidebar from "./components/Sidebar";
 import Pagination from "./components/Pagination";
 import VideoCard from "./components/VideoCard";
-import { getVideosPaths } from "./api";
+import { getVideosPaths } from "@/lib/clientApi";
 
 interface VideoPath { path: string }
 interface VideoResponse { videos: VideoPath[]; total: number }

--- a/lib/clientApi.ts
+++ b/lib/clientApi.ts
@@ -12,7 +12,6 @@ export async function getModels() {
 }
 
 export async function deleteModel(id: number) {
-  // Use the id as a path parameter
   const url = new URL(`http://localhost:3001/model/${id}`);
 
   const response = await fetch(url, {
@@ -27,8 +26,6 @@ export async function deleteModel(id: number) {
   }
   return response.json();
 }
-
-// ./api/index.ts
 
 export async function getVideosPaths(page = 1, pageSize = 6) {
   const url = new URL(`http://localhost:3001/vids`);
@@ -46,7 +43,5 @@ export async function getVideosPaths(page = 1, pageSize = 6) {
     throw new Error(`Failed to get videos paths. Status: ${response.status}`);
   }
 
-  return await response.json(); // Expected: { videos: [...], total: 123 }
+  return await response.json();
 }
- 
-


### PR DESCRIPTION
## Changes Made

### File Structure
- Moved `app/api.ts` to `lib/clientApi.ts`
- Updated import path in `app/page.tsx` from `./api` to `@/lib/clientApi`

### Code Cleanup
- Removed inline comment "Use the id as a path parameter" in `deleteModel` function
- Removed file header comment "// ./api/index.ts"
- Removed inline comment "Expected: { videos: [...], total: 123 }" from `getVideosPaths` function
- Removed trailing whitespace at end of file

### Functions Affected
- `getModels()`
- `deleteModel(id: number)`
- `getVideosPaths(page = 1, pageSize = 6)`

All function implementations remain unchanged, only location and comments were modified.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e1c60600c2e44a4d8dd8a29d83ee0012/spark-space)

👀 [Preview Link](https://e1c60600c2e44a4d8dd8a29d83ee0012-spark-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e1c60600c2e44a4d8dd8a29d83ee0012</projectId>-->
<!--<branchName>spark-space</branchName>-->