### PR TITLE
Remove horizontal padding from main layout components

### DIFF
--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -156,7 +156,7 @@ const OnlinePage = () => {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
       <Sidebar />
-      <main className={`px-4 sm:px-6 lg:px-8 py-6 transition-[margin] duration-300 ${isOpen ? "md:ml-64" : "ml-0"}`}>
+      <main className={`py-6 transition-[margin] duration-300 ${isOpen ? "md:ml-64" : "ml-0"}`}>
         <div className="max-w-7xl mx-auto">
         <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-6">
           <div>

--- a/app/all-videos-page.tsx
+++ b/app/all-videos-page.tsx
@@ -23,7 +23,7 @@ const AllVideosPage = () => {
   }, []);
 
   return (
-    <div className="p-6">
+    <div className="py-6">
       <h1 className="text-2xl font-bold mb-6">Toate videourile</h1>
       {loading && <p>Loading...</p>}
       {!loading && allVideos.length === 0 && <p>Nu există videouri.</p>}

--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -41,7 +41,7 @@ export default function CategoryPage() {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
       <Sidebar />
-      <main className={`px-4 sm:px-6 lg:px-8 py-6 transition-[margin] duration-300 ${isOpen ? "md:ml-64" : "ml-0"}`}>
+      <main className={`py-6 transition-[margin] duration-300 ${isOpen ? "md:ml-64" : "ml-0"}`}>
         <div className="max-w-7xl mx-auto">
           <MediaGallery
             apiEndpoint={`/api/images/${encodeURIComponent(cfg.apiBasePath)}`}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,7 +49,7 @@ export default function VideoPage() {
   return (
     <div className="relative">
       <Sidebar />
-      <section className={`${isOpen ? "md:ml-64" : "md:ml-0"} ml-0 p-4 md:p-8 transition-[margin] duration-300`}>
+      <section className={`${isOpen ? "md:ml-64" : "md:ml-0"} ml-0 py-4 md:py-8 transition-[margin] duration-300`}>
         <h1 className="sr-only">Latest Videos</h1>
         {error && (
           <div role="alert" className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">

--- a/app/profile/[id]/page.tsx
+++ b/app/profile/[id]/page.tsx
@@ -166,7 +166,7 @@ const ModelProfile = () => {
   return (
     <div className="bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 min-h-screen">
       <Sidebar />
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="max-w-7xl mx-auto py-8">
         {/* Profile Header Section */}
         <div className="flex flex-col lg:flex-row gap-8 items-start lg:items-center mb-12">
           {/* Avatar Section */}


### PR DESCRIPTION
## Purpose
The user requested to remove the distance/spacing from the left and right borders across the application layout.

## Code changes
- Removed horizontal padding (`px-4`, `px-6`, `px-8`) from main layout components across multiple pages
- Kept vertical padding (`py-6`, `py-8`) to maintain proper spacing
- Updated the following files:
  - `app/Online/page.tsx`: Removed `px-4 sm:px-6 lg:px-8` from main element
  - `app/all-videos-page.tsx`: Changed `p-6` to `py-6`
  - `app/category/[slug]/page.tsx`: Removed `px-4 sm:px-6 lg:px-8` from main element
  - `app/page.tsx`: Changed `p-4 md:p-8` to `py-4 md:py-8`
  - `app/profile/[id]/page.tsx`: Removed `px-4 sm:px-6 lg:px-8` from container div

This change creates a full-width layout by eliminating the left and right margins/padding while preserving vertical spacing.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e1c60600c2e44a4d8dd8a29d83ee0012/flare-space)

👀 [Preview Link](https://e1c60600c2e44a4d8dd8a29d83ee0012-flare-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e1c60600c2e44a4d8dd8a29d83ee0012</projectId>-->
<!--<branchName>flare-space</branchName>-->