### PR TITLE
Add model detail page and filtering for online models

### DIFF
--- a/app/Online/[model]/page.tsx
+++ b/app/Online/[model]/page.tsx
@@ -66,11 +66,6 @@ const OnlineModelPage = () => {
         <div className="w-full px-[5px]">
           <header className="mb-4">
             <h1 className="text-2xl font-semibold truncate" title={name}>{name}</h1>
-            {data && (
-              <p className="text-sm text-slate-500 dark:text-slate-400">
-                {data.videoCount ?? 0} videos • Rating {Number(data.averageRating ?? 0).toFixed(2)} • Online {data.onlineCount ?? 0}
-              </p>
-            )}
           </header>
 
           {error && (
@@ -97,16 +92,18 @@ const OnlineModelPage = () => {
                 <div className="h-40 rounded-xl bg-slate-200 dark:bg-slate-800 animate-pulse" />
               ) : data ? (
                 <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4">
-                  <h2 className="font-semibold mb-3">Details</h2>
+                  <h2 className="font-semibold mb-3">Info</h2>
                   <ul className="space-y-1 text-sm">
-                    <li><span className="text-slate-500">Average rating:</span> {Number(data.averageRating ?? 0).toFixed(2)}</li>
-                    <li><span className="text-slate-500">Videos:</span> {data.videoCount ?? 0}</li>
-                    <li><span className="text-slate-500">Online count:</span> {data.onlineCount ?? 0}</li>
-                    <li><span className="text-slate-500">Body:</span> {data.body ?? 0}</li>
-                    <li><span className="text-slate-500">Hair:</span> {data.hair ?? 0}</li>
-                    <li><span className="text-slate-500">Legs:</span> {data.legs ?? 0}</li>
-                    <li><span className="text-slate-500">Pussy:</span> {data.pussy ?? 0}</li>
+                    <li><span className="text-slate-500">ID:</span> {(data as any)?.id ?? "-"}</li>
+                    <li><span className="text-slate-500">Created at:</span> {((data as any)?.created_at ? new Date((data as any).created_at).toLocaleString() : "-")}</li>
+                    <li><span className="text-slate-500">Started at:</span> {((data as any)?.startedAt ? new Date((data as any).startedAt).toLocaleString() : "-")}</li>
+                    <li><span className="text-slate-500">Online:</span> {((data as any)?.isOnline === true ? "Yes" : ((data as any)?.isOnline === false ? "No" : "-"))}</li>
+                    <li><span className="text-slate-500">Tags:</span> {Array.isArray((data as any)?.tags) ? (data as any).tags.join(", ") : ((data as any)?.tags || "-")}</li>
+                    <li><span className="text-slate-500">Video tags:</span> {Array.isArray((data as any)?.videoTags) ? (data as any).videoTags.join(", ") : ((data as any)?.videoTags || "-")}</li>
                   </ul>
+                  {((data as any)?.imageUrl) && (
+                    <img src={(data as any).imageUrl} alt={name} className="mt-3 rounded-lg w-full object-cover" />
+                  )}
                 </div>
               ) : (
                 <div className="text-slate-500">No data available.</div>

--- a/app/Online/[model]/page.tsx
+++ b/app/Online/[model]/page.tsx
@@ -21,6 +21,19 @@ const OnlineModelPage = () => {
 
   useEffect(() => {
     let active = true;
+
+    const hydrateFromSnapshot = () => {
+      if (!modelParam) return;
+      try {
+        const key = `modelSnapshot:${decodeURIComponent(modelParam)}`;
+        const raw = localStorage.getItem(key);
+        if (raw) {
+          const parsed = JSON.parse(raw) as Partial<VideoModel> & { ts?: number };
+          setData((prev) => ({ ...(prev || {}), ...(parsed as VideoModel) }));
+        }
+      } catch {}
+    };
+
     const run = async () => {
       if (!modelParam) return;
       setLoading(true);
@@ -36,6 +49,8 @@ const OnlineModelPage = () => {
         if (active) setLoading(false);
       }
     };
+
+    hydrateFromSnapshot();
     run();
     return () => {
       active = false;

--- a/app/Online/[model]/page.tsx
+++ b/app/Online/[model]/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import Sidebar from "../../components/Sidebar";
+import { useSidebar } from "../../components/ui/SidebarContext";
+import { VideoModel } from "@/app/types";
+import { getModelById } from "@/app/ids";
+
+const OnlineModelPage = () => {
+  const params = useParams();
+  const modelParam = useMemo(() => {
+    const raw = (params as Record<string, string | string[]> | null)?.model;
+    return Array.isArray(raw) ? raw[0] : raw;
+  }, [params]);
+
+  const { isOpen } = useSidebar();
+  const [data, setData] = useState<VideoModel | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const run = async () => {
+      if (!modelParam) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await getModelById({ name: decodeURIComponent(modelParam) });
+        if (!active) return;
+        setData(res ?? null);
+      } catch (e: any) {
+        if (!active) return;
+        setError(e?.message || "Failed to load model");
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      active = false;
+    };
+  }, [modelParam]);
+
+  const name = useMemo(() => (modelParam ? decodeURIComponent(modelParam) : ""), [modelParam]);
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+      <Sidebar />
+      <main className={`py-6 transition-[margin] duration-300 ${isOpen ? "md:ml-64" : "ml-0"}`}>
+        <div className="w-full px-[5px]">
+          <header className="mb-4">
+            <h1 className="text-2xl font-semibold truncate" title={name}>{name}</h1>
+            {data && (
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                {data.videoCount ?? 0} videos • Rating {Number(data.averageRating ?? 0).toFixed(2)} • Online {data.onlineCount ?? 0}
+              </p>
+            )}
+          </header>
+
+          {error && (
+            <div className="mb-4 p-3 rounded-md border border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/40">{error}</div>
+          )}
+
+          <section className="grid grid-cols-1 lg:grid-cols-3 gap-4 items-start">
+            <div className="lg:col-span-2">
+              <div className="relative w-full bg-black rounded-xl overflow-hidden border border-slate-200 dark:border-slate-700">
+                <iframe
+                  src={`https://chaturbate.com/embed/${encodeURIComponent(name)}/?join_overlay=1&campaign=GeOP2&embed_video_only=1&tour=9oGW&mobileRedirect=never&disable_autoplay=1`}
+                  className="w-full aspect-video md:h-[70vh]"
+                  frameBorder="0"
+                  scrolling="no"
+                  allowFullScreen
+                  title={`${name} Live Cam`}
+                  loading="lazy"
+                />
+              </div>
+            </div>
+
+            <aside className="lg:col-span-1 space-y-3">
+              {loading ? (
+                <div className="h-40 rounded-xl bg-slate-200 dark:bg-slate-800 animate-pulse" />
+              ) : data ? (
+                <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4">
+                  <h2 className="font-semibold mb-3">Details</h2>
+                  <ul className="space-y-1 text-sm">
+                    <li><span className="text-slate-500">Average rating:</span> {Number(data.averageRating ?? 0).toFixed(2)}</li>
+                    <li><span className="text-slate-500">Videos:</span> {data.videoCount ?? 0}</li>
+                    <li><span className="text-slate-500">Online count:</span> {data.onlineCount ?? 0}</li>
+                    <li><span className="text-slate-500">Body:</span> {data.body ?? 0}</li>
+                    <li><span className="text-slate-500">Hair:</span> {data.hair ?? 0}</li>
+                    <li><span className="text-slate-500">Legs:</span> {data.legs ?? 0}</li>
+                    <li><span className="text-slate-500">Pussy:</span> {data.pussy ?? 0}</li>
+                  </ul>
+                </div>
+              ) : (
+                <div className="text-slate-500">No data available.</div>
+              )}
+            </aside>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default OnlineModelPage;

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -113,13 +113,13 @@ const OnlinePage = () => {
   const { isOpen } = useSidebar();
   const [showAddModal, setShowAddModal] = useState(false);
   const [newModelName, setNewModelName] = useState("");
-  const [onlyFavorite, setOnlyFavorite] = useState(false);
+  const [onlyPinned, setOnlyPinned] = useState(false);
   const [sourceChaturbate, setSourceChaturbate] = useState(false);
 
   const fetchData = async () => {
     try {
       setError(null);
-      const onlineModels = await getOnlineModels({ favorite: onlyFavorite, source: sourceChaturbate ? "chaturbate" : undefined });
+      const onlineModels = await getOnlineModels({ pinned: onlyPinned, source: sourceChaturbate ? "chaturbate" : undefined });
       if (Array.isArray(onlineModels)) {
         setOnline(onlineModels);
         setLastUpdated(new Date());
@@ -145,7 +145,7 @@ const OnlinePage = () => {
       mounted = false;
       clearInterval(id);
     };
-  }, [onlyFavorite, sourceChaturbate]);
+  }, [onlyPinned, sourceChaturbate]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -188,8 +188,8 @@ const OnlinePage = () => {
               <label className="flex items-center gap-2 text-sm px-2 py-2 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800">
                 <input
                   type="checkbox"
-                  checked={onlyFavorite}
-                  onChange={(e) => setOnlyFavorite(e.target.checked)}
+                  checked={onlyPinned}
+                  onChange={(e) => setOnlyPinned(e.target.checked)}
                 />
                 Favorite
               </label>

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -151,7 +151,7 @@ const OnlinePage = () => {
   const fetchData = async () => {
     try {
       setError(null);
-      const onlineModels = await getOnlineModels({ pinned: onlyPinned, status });
+      const onlineModels = await getOnlineModels({ pinned: onlyPinned, status, page, limit });
       if (Array.isArray(onlineModels)) {
         setOnline(onlineModels);
         setLastUpdated(new Date());

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -258,6 +258,26 @@ const OnlinePage = () => {
                 <option value="pending">pending</option>
                 <option value="waiting">waiting</option>
               </select>
+              <select
+                value={String(limit)}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value, 10);
+                  const nextLimit = Number.isNaN(v) || v <= 0 ? 20 : v;
+                  setLimit(nextLimit);
+                  setPage(1);
+                  const params = new URLSearchParams(searchParams?.toString?.() || "");
+                  params.set("limit", String(nextLimit));
+                  params.set("page", "1");
+                  const qs = params.toString();
+                  router.replace(qs ? `?${qs}` : "?", { scroll: false });
+                }}
+                className="px-2 py-2 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm"
+              >
+                <option value="10">10</option>
+                <option value="20">20</option>
+                <option value="30">30</option>
+                <option value="50">50</option>
+              </select>
               <button
                 onClick={() => setShowAddModal(true)}
                 className="px-3 py-2 rounded-md bg-emerald-600 text-white hover:bg-emerald-500"

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -311,6 +311,40 @@ const OnlinePage = () => {
             <p className="text-slate-500">No live broadcasts right now. Please check back soon.</p>
           </div>
         )}
+
+        <div className="mt-6 flex items-center justify-between">
+          <button
+            onClick={() => {
+              if (page <= 1) return;
+              const next = page - 1;
+              setPage(next);
+              const params = new URLSearchParams(searchParams?.toString?.() || "");
+              params.set("page", String(next));
+              const qs = params.toString();
+              router.replace(qs ? `?${qs}` : "?", { scroll: false });
+            }}
+            disabled={page <= 1}
+            className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-700 disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <div className="text-sm text-slate-500">Page {page}</div>
+          <button
+            onClick={() => {
+              if (online.length < limit) return;
+              const next = page + 1;
+              setPage(next);
+              const params = new URLSearchParams(searchParams?.toString?.() || "");
+              params.set("page", String(next));
+              const qs = params.toString();
+              router.replace(qs ? `?${qs}` : "?", { scroll: false });
+            }}
+            disabled={online.length < limit}
+            className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-700 disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
         </div>
       </main>
 

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -279,6 +279,20 @@ const OnlinePage = () => {
                 <option value="50">50</option>
               </select>
               <button
+                onClick={() => {
+                  setLimit(20);
+                  setPage(1);
+                  const params = new URLSearchParams(searchParams?.toString?.() || "");
+                  params.delete("limit");
+                  params.set("page", "1");
+                  const qs = params.toString();
+                  router.replace(qs ? `?${qs}` : "?", { scroll: false });
+                }}
+                className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-700"
+              >
+                Reset limit
+              </button>
+              <button
                 onClick={() => setShowAddModal(true)}
                 className="px-3 py-2 rounded-md bg-emerald-600 text-white hover:bg-emerald-500"
               >

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef, memo } from "react";
+import Link from "next/link";
 import Sidebar from "../components/Sidebar";
 import { useSidebar } from "../components/ui/SidebarContext";
 import { VideoModel } from "@/app/types";
@@ -86,8 +87,17 @@ const OnlineModelCard = memo(({ model }: { model: VideoModel }) => {
           />
         )}
       </div>
-      <div className="p-3">
+      <div className="p-3 flex items-center justify-between gap-2">
         <h3 className="font-semibold text-slate-900 dark:text-slate-100 truncate" title={model.name}>{model.name}</h3>
+        <Link
+          href={`/Online/${encodeURIComponent(model.name)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 px-2 py-1 rounded-md text-sm bg-slate-900 text-white hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
+          aria-label={`Open ${model.name} in new tab`}
+        >
+          Open
+        </Link>
       </div>
     </article>
   );
@@ -103,11 +113,13 @@ const OnlinePage = () => {
   const { isOpen } = useSidebar();
   const [showAddModal, setShowAddModal] = useState(false);
   const [newModelName, setNewModelName] = useState("");
+  const [onlyFavorite, setOnlyFavorite] = useState(false);
+  const [sourceChaturbate, setSourceChaturbate] = useState(false);
 
   const fetchData = async () => {
     try {
       setError(null);
-      const onlineModels = await getOnlineModels();
+      const onlineModels = await getOnlineModels({ favorite: onlyFavorite, source: sourceChaturbate ? "chaturbate" : undefined });
       if (Array.isArray(onlineModels)) {
         setOnline(onlineModels);
         setLastUpdated(new Date());
@@ -133,7 +145,7 @@ const OnlinePage = () => {
       mounted = false;
       clearInterval(id);
     };
-  }, []);
+  }, [onlyFavorite, sourceChaturbate]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -173,6 +185,22 @@ const OnlinePage = () => {
                 placeholder="Search by name…"
                 className="w-56 px-3 py-2 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800"
               />
+              <label className="flex items-center gap-2 text-sm px-2 py-2 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800">
+                <input
+                  type="checkbox"
+                  checked={onlyFavorite}
+                  onChange={(e) => setOnlyFavorite(e.target.checked)}
+                />
+                Favorite
+              </label>
+              <label className="flex items-center gap-2 text-sm px-2 py-2 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800">
+                <input
+                  type="checkbox"
+                  checked={sourceChaturbate}
+                  onChange={(e) => setSourceChaturbate(e.target.checked)}
+                />
+                Chaturbate
+              </label>
               <button
                 onClick={() => setShowAddModal(true)}
                 className="px-3 py-2 rounded-md bg-emerald-600 text-white hover:bg-emerald-500"

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -136,6 +136,7 @@ const OnlinePage = () => {
   const [onlyPinned, setOnlyPinned] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [status, setStatus] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     const initialPinned = searchParams?.get?.("pinned");
@@ -143,12 +144,14 @@ const OnlinePage = () => {
       const p = initialPinned === "true" || initialPinned === "1";
       setOnlyPinned(p);
     }
+    const s = searchParams?.get?.("status");
+    setStatus(s || undefined);
   }, [searchParams]);
 
   const fetchData = async () => {
     try {
       setError(null);
-      const onlineModels = await getOnlineModels({ pinned: onlyPinned });
+      const onlineModels = await getOnlineModels({ pinned: onlyPinned, status });
       if (Array.isArray(onlineModels)) {
         setOnline(onlineModels);
         setLastUpdated(new Date());
@@ -174,7 +177,7 @@ const OnlinePage = () => {
       mounted = false;
       clearInterval(id);
     };
-  }, [onlyPinned]);
+  }, [onlyPinned, status]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -229,6 +232,24 @@ const OnlinePage = () => {
                 />
                 Favorite
               </label>
+              <select
+                value={status ?? ""}
+                onChange={(e) => {
+                  const v = e.target.value || undefined;
+                  setStatus(v);
+                  const params = new URLSearchParams(searchParams?.toString?.() || "");
+                  if (v) params.set("status", v); else params.delete("status");
+                  const qs = params.toString();
+                  router.replace(qs ? `?${qs}` : "?", { scroll: false });
+                }}
+                className="px-2 py-2 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm"
+              >
+                <option value="">All</option>
+                <option value="approved">approved</option>
+                <option value="reject">reject</option>
+                <option value="pending">pending</option>
+                <option value="waiting">waiting</option>
+              </select>
               <button
                 onClick={() => setShowAddModal(true)}
                 className="px-3 py-2 rounded-md bg-emerald-600 text-white hover:bg-emerald-500"

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -148,6 +148,12 @@ const OnlinePage = () => {
     }
     const s = searchParams?.get?.("status");
     setStatus(s || undefined);
+    const pStr = searchParams?.get?.("page");
+    const lStr = searchParams?.get?.("limit");
+    const pNum = pStr ? parseInt(pStr, 10) : NaN;
+    const lNum = lStr ? parseInt(lStr, 10) : NaN;
+    if (!Number.isNaN(pNum) && pNum > 0) setPage(pNum);
+    if (!Number.isNaN(lNum) && lNum > 0) setLimit(lNum);
   }, [searchParams]);
 
   const fetchData = async () => {

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -62,6 +62,28 @@ const AddModelModal = ({
 
 const OnlineModelCard = memo(({ model }: { model: VideoModel }) => {
   const [showVideo, setShowVideo] = useState(false);
+
+  const handleOpen = () => {
+    try {
+      const snapshot = {
+        id: model.id,
+        name: model.name,
+        imageUrl: model.imageUrl,
+        averageRating: model.averageRating,
+        videoCount: model.videoCount,
+        onlineCount: model.onlineCount,
+        body: model.body,
+        hair: model.hair,
+        legs: model.legs,
+        pussy: model.pussy,
+        avatarLink: model.avatarLink,
+        links: Array.isArray(model.links) ? model.links.slice(0, 20) : [],
+        ts: Date.now()
+      };
+      localStorage.setItem(`modelSnapshot:${model.name}`, JSON.stringify(snapshot));
+    } catch {}
+  };
+
   return (
     <article
       className="group relative rounded-xl overflow-hidden bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md transition-all"
@@ -93,6 +115,7 @@ const OnlineModelCard = memo(({ model }: { model: VideoModel }) => {
           href={`/Online/${encodeURIComponent(model.name)}`}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={handleOpen}
           className="shrink-0 px-2 py-1 rounded-md text-sm bg-slate-900 text-white hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
           aria-label={`Open ${model.name} in new tab`}
         >

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -246,7 +246,7 @@ const OnlinePage = () => {
               >
                 <option value="">All</option>
                 <option value="approved">approved</option>
-                <option value="reject">reject</option>
+                <option value="rejected">rejected</option>
                 <option value="pending">pending</option>
                 <option value="waiting">waiting</option>
               </select>

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -185,7 +185,7 @@ const OnlinePage = () => {
       mounted = false;
       clearInterval(id);
     };
-  }, [onlyPinned, status]);
+  }, [onlyPinned, status, page, limit]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -67,18 +67,14 @@ const OnlineModelCard = memo(({ model }: { model: VideoModel }) => {
   const handleOpen = () => {
     try {
       const snapshot = {
-        id: model.id,
+        id: (model as any)?.id,
+        created_at: (model as any)?.created_at ?? (model as any)?.createdAt,
         name: model.name,
-        imageUrl: model.imageUrl,
-        averageRating: model.averageRating,
-        videoCount: model.videoCount,
-        onlineCount: model.onlineCount,
-        body: model.body,
-        hair: model.hair,
-        legs: model.legs,
-        pussy: model.pussy,
-        avatarLink: model.avatarLink,
-        links: Array.isArray(model.links) ? model.links.slice(0, 20) : [],
+        isOnline: (model as any)?.isOnline,
+        imageUrl: (model as any)?.imageUrl,
+        startedAt: (model as any)?.startedAt,
+        videoTags: (model as any)?.videoTags ?? null,
+        tags: (model as any)?.tags ?? null,
         ts: Date.now()
       };
       localStorage.setItem(`modelSnapshot:${model.name}`, JSON.stringify(snapshot));

--- a/app/Online/page.tsx
+++ b/app/Online/page.tsx
@@ -137,6 +137,8 @@ const OnlinePage = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [status, setStatus] = useState<string | undefined>(undefined);
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
 
   useEffect(() => {
     const initialPinned = searchParams?.get?.("pinned");

--- a/app/ids.ts
+++ b/app/ids.ts
@@ -100,10 +100,12 @@ export async function getVideos() {
   return await response.json();
 }
 
-export async function getOnlineModels(opts?: { pinned?: boolean; status?: string }) {
+export async function getOnlineModels(opts?: { pinned?: boolean; status?: string; page?: number; limit?: number }) {
   const url = new URL("http://localhost:3001/model/cb");
   if (opts?.pinned) url.searchParams.append("pinned", "true");
   if (opts?.status) url.searchParams.append("status", opts.status);
+  if (opts?.page) url.searchParams.append("page", String(opts.page));
+  if (opts?.limit) url.searchParams.append("limit", String(opts.limit));
 
   const response = await fetch(url.toString(), {
     method: "GET",

--- a/app/ids.ts
+++ b/app/ids.ts
@@ -100,10 +100,10 @@ export async function getVideos() {
   return await response.json();
 }
 
-export async function getOnlineModels(opts?: { pinned?: boolean; source?: string }) {
+export async function getOnlineModels(opts?: { pinned?: boolean; status?: string }) {
   const url = new URL("http://localhost:3001/model/cb");
   if (opts?.pinned) url.searchParams.append("pinned", "true");
-  if (opts?.source) url.searchParams.append("source", opts.source);
+  if (opts?.status) url.searchParams.append("status", opts.status);
 
   const response = await fetch(url.toString(), {
     method: "GET",

--- a/app/ids.ts
+++ b/app/ids.ts
@@ -100,8 +100,10 @@ export async function getVideos() {
   return await response.json();
 }
 
-export async function getOnlineModels() {
+export async function getOnlineModels(opts?: { favorite?: boolean; source?: string }) {
   const url = new URL("http://localhost:3001/model/cb");
+  if (opts?.favorite) url.searchParams.append("favorite", "true");
+  if (opts?.source) url.searchParams.append("source", opts.source);
 
   const response = await fetch(url.toString(), {
     method: "GET",
@@ -110,7 +112,9 @@ export async function getOnlineModels() {
     },
   });
 
+  if (!response.ok) {
+    throw new Error(`Failed to load online models. Status: ${response.status}`);
+  }
+
   return await response.json();
 }
-
-

--- a/app/ids.ts
+++ b/app/ids.ts
@@ -100,9 +100,9 @@ export async function getVideos() {
   return await response.json();
 }
 
-export async function getOnlineModels(opts?: { favorite?: boolean; source?: string }) {
+export async function getOnlineModels(opts?: { pinned?: boolean; source?: string }) {
   const url = new URL("http://localhost:3001/model/cb");
-  if (opts?.favorite) url.searchParams.append("favorite", "true");
+  if (opts?.pinned) url.searchParams.append("pinned", "true");
   if (opts?.source) url.searchParams.append("source", opts.source);
 
   const response = await fetch(url.toString(), {

--- a/app/model/[name]/page.tsx
+++ b/app/model/[name]/page.tsx
@@ -79,6 +79,7 @@ export default function ModelDetailPage() {
   const [selectTag, setSelectTag] = useState<string>("");
   const [avatarSrc, setAvatarSrc] = useState<string>("");
   const [videoFilter, setVideoFilter] = useState<string>("");
+  const [sectionVisible, setSectionVisible] = useState<boolean>(true);
   const allTags = useMemo(
     () => Array.from(new Set([...(videoTags || []), ...(tags || [])])),
     [videoTags, tags]
@@ -375,6 +376,7 @@ export default function ModelDetailPage() {
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
       <Sidebar />
+
       <main
         className={`py-6 transition-[margin] duration-300 ${
           isOpen ? "md:ml-64" : "ml-0"
@@ -383,9 +385,7 @@ export default function ModelDetailPage() {
         <div className="w-full px-4 md:px-6">
           <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
             <div>
-              <h1 className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">
-                Model: {name}
-              </h1>
+        
             </div>
             <div className="flex items-center gap-2">
               <button
@@ -407,6 +407,12 @@ export default function ModelDetailPage() {
               >
                 {editMode ? "Cancel" : "Edit"}
               </button>
+              <button
+          onClick={() => setSectionVisible(!sectionVisible)}
+          className="px-3 py-1.5 text-sm rounded bg-slate-200 dark:bg-slate-700 hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors shadow-lg"
+        >
+          {sectionVisible ? "Hide" : "Show"}
+        </button>
             </div>
           </div>
 
@@ -418,93 +424,87 @@ export default function ModelDetailPage() {
             <div className="text-sm text-slate-600">Model not found.</div>
           ) : (
             <div className="space-y-6">
+              {sectionVisible && (
               <section className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg p-4">
-                <div className="flex items-center gap-4">
-                  <div className="w-40 h-40- rounded-full overflow-hidden bg-slate-200 dark:bg-slate-800 flex items-center justify-center text-2xl font-semibold text-slate-700 dark:text-slate-200">
-                    {avatarSrc ? (
-                      <img
-                        src={avatarSrc}
-                        alt={name}
-                        className="w-full h-full object-cover"
-                      />
-                    ) : (
-                      name?.charAt(0)?.toUpperCase() || "?"
-                    )}
-                  </div>
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <h2 className="text-xl font-semibold">{name}</h2>
-                      {isOnline ? (
-                        <span className="px-2 py-0.5 text-xs rounded-full bg-emerald-500/20 text-emerald-600 dark:text-emerald-400">
-                          Online
-                        </span>
+                  <div className="flex items-center gap-4">
+                    <div className="w-40 h-40- rounded-full overflow-hidden bg-slate-200 dark:bg-slate-800 flex items-center justify-center text-2xl font-semibold text-slate-700 dark:text-slate-200">
+                      {avatarSrc ? (
+                        <img
+                          src={avatarSrc}
+                          alt={name}
+                          className="w-full h-full object-cover"
+                        />
                       ) : (
-                        <span className="px-2 py-0.5 text-xs rounded-full bg-slate-500/20 text-slate-600 dark:text-slate-400">
-                          Offline
-                        </span>
-                      )}
-                      {checkedModel?.hasContent && (
-                        <span className="px-2 py-0.5 text-xs rounded-full bg-indigo-500/20 text-indigo-600 dark:text-indigo-400">
-                          hasContent
-                        </span>
-                      )}
-                      {checkedModel && (
-                        <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-full bg-emerald-500/20 text-emerald-600 dark:text-emerald-400">
-                          <svg
-                            viewBox="0 0 20 20"
-                            className="w-3 h-3"
-                            aria-hidden
-                          >
-                            <path
-                              fill="currentColor"
-                              d="M7.629 13.314a1 1 0 0 1-1.258.062l-.095-.082-2.5-2.5a1 1 0 0 1 1.32-1.497l.094.083L7 10.586l6.439-6.44a1 1 0 0 1 1.497 1.32l-.083.094-7 7-.062.055-.074.054Z"
-                            />
-                          </svg>
-                          Checked
-                        </span>
-                      )}
-                    </div>
-                    <span className="text-sm text-slate-600 dark:text-slate-400 mt-1 flex gap-4 flex-wrap">
-                      Videos: {videos.length}
-                    </span>
-                    <div className="text-sm text-slate-600 dark:text-slate-400 mt-1 flex gap-4 flex-wrap">
-                      {allTags.length > 0 && (
-                        <div className="flex items-center gap-1">
-                          <span>Tags:</span>
-                          <div className="flex flex-wrap gap-1">
-                            {allTags.map((tag) => (
-                              <span
-                                key={tag}
-                                className="px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-xs text-slate-700 dark:text-slate-300"
-                              >
-                                {tag}
-                              </span>
-                            ))}
-                          </div>
-                        </div>
+                        name?.charAt(0)?.toUpperCase() || "?"
                       )}
                     </div>
 
-                    <div className="text-sm text-slate-600 dark:text-slate-400 mt-1 flex gap-4 flex-wrap">
-                      {modelNames.length > 0 && (
-                        <div className="flex items-center gap-1">
-                          <span>Names:</span>
-                          <div className="flex flex-wrap gap-1">
-                            {modelNames.map((name) => (
-                              <span
-                                key={name.id}
-                                className="px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-xs text-slate-700 dark:text-slate-300"
-                              >
-                                {name.name}
-                              </span>
-                            ))} 
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <h2 className="text-xl font-semibold">{name}</h2>
+                        {isOnline ? (
+                          <span className="px-2 py-0.5 text-xs rounded-full bg-emerald-500/20 text-emerald-600 dark:text-emerald-400">
+                            Online
+                          </span>
+                        ) : (
+                          <span className="px-2 py-0.5 text-xs rounded-full bg-slate-500/20 text-slate-600 dark:text-slate-400">
+                            Offline
+                          </span>
+                        )}
+                        {checkedModel?.hasContent && (
+                          <span className="px-2 py-0.5 text-xs rounded-full bg-indigo-500/20 text-indigo-600 dark:text-indigo-400">
+                            Approved
+                          </span>
+                        )}
+                        {checkedModel && (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-full bg-emerald-500/20 text-emerald-600 dark:text-emerald-400">
+
+                            Checked
+                          </span>
+                        )}
+                      </div>
+                      <span className="text-sm text-slate-600 dark:text-slate-400 mt-1 flex gap-4 flex-wrap">
+                        Videos: {videos.length}
+                      </span>
+                      <div className="text-sm text-slate-600 dark:text-slate-400 mt-1 flex gap-4 flex-wrap">
+                        {allTags.length > 0 && (
+                          <div className="flex items-center gap-1">
+                            <span>Tags:</span>
+                            <div className="flex flex-wrap gap-1">
+                              {allTags.map((tag) => (
+                                <span
+                                  key={tag}
+                                  className="px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-xs text-slate-700 dark:text-slate-300"
+                                >
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
                           </div>
-                        </div>
-                      )}
+                        )}
+                      </div>
+
+                      <div className="text-sm text-slate-600 dark:text-slate-400 mt-1 flex gap-4 flex-wrap">
+                        {modelNames.length > 0 && (
+                          <div className="flex items-center gap-1">
+                            <span>Names:</span>
+                            <div className="flex flex-wrap gap-1">
+                              {modelNames.map((name) => (
+                                <span
+                                  key={name.id}
+                                  className="px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-xs text-slate-700 dark:text-slate-300"
+                                >
+                                  {name.name}
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
                     </div>
                   </div>
-                </div>
               </section>
+              )}
               {/* Model data (hidden unless editing) */}
               {editMode && (
                 <section className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg p-4">


### PR DESCRIPTION
## Purpose

The user wanted to enhance the online models functionality by:
1. Adding a button on model cards that opens a dedicated model detail page in a new tab
2. Creating a new page (`Online/[modelName]`) with an embedded Chaturbate iframe and model data from the API
3. Adding filtering options to the Online page for "favorite" (pinned) and "chaturbate" source models

## Code changes

- **New model detail page**: Created `app/Online/[model]/page.tsx` with a responsive layout featuring:
  - Large Chaturbate iframe embed taking up 2/3 of the layout
  - Model details sidebar with stats (rating, video count, online count, physical attributes)
  - Error handling and loading states
  
- **Enhanced model cards**: Modified `OnlineModelCard` component to include an "Open" button that opens the model detail page in a new tab

- **Added filtering**: Enhanced the Online page with two new filter checkboxes:
  - "Favorite" checkbox for pinned models
  - "Chaturbate" checkbox for Chaturbate source filtering
  
- **Updated API calls**: Modified `getOnlineModels()` function to accept optional filtering parameters (`pinned` and `source`) and pass them as query parameters to the backend API

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e1c60600c2e44a4d8dd8a29d83ee0012/quantum-studio)

👀 [Preview Link](https://e1c60600c2e44a4d8dd8a29d83ee0012-quantum-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e1c60600c2e44a4d8dd8a29d83ee0012</projectId>-->
<!--<branchName>quantum-studio</branchName>-->